### PR TITLE
Don't exit app if one job cannot be found

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func main() {
 		err = jobClient.Delete(job.ObjectMeta.Name, deletionOptions)
 
 		if err != nil {
-			log.Fatal(err.Error())
+			log.Warnf(err.Error())
 		}
 	}
 }


### PR DESCRIPTION
### Problem
Since `log.Fatal` exits the app ( https://golang.org/pkg/log/#Fatal ), kube-janitor was exiting on any failed-to-find job, which caused jobs to pile up.

```
time="2019-04-02T03:59:44Z" level=debug msg="(7596) jobs found"
time="2019-04-02T03:59:44Z" level=debug msg="(7595) jobs to remove"
time="2019-04-02T03:59:45Z" level=info msg="Deleting (namespace:my-job-d5qxr)"
time="2019-04-02T03:59:45Z" level=fatal msg="jobs.batch \"my-job-d5qxr\" not found"
# EXITS
```

### Solution
Reduce log level

@theMagicalKarp @sunghoonkim-wk 

